### PR TITLE
fix static build with readline

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,8 @@ AC_PROG_AWK
 AC_CHECK_FUNCS(getopt_long)
 
 PKG_CHECK_MODULES([LIBNL3], [libnl-3.0], [], [AC_MSG_ERROR([libnl-3.0 is required])])
+# Fallback on using -lreadline as readline.pc is only available since version 8.0
+PKG_CHECK_MODULES([READLINE], [readline], [], [READLINE_LIBS=-lreadline])
 
 AC_OUTPUT(Makefile src/Makefile doc/Makefile tests/Makefile)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,8 +1,8 @@
 
 bin_PROGRAMS = dropwatch
 
-AM_CFLAGS = -g -Wall -Werror $(LIBNL3_CFLAGS)
-AM_LDFLAGS = $(LIBNL3_LIBS) -lnl-genl-3 -lbfd -lreadline
+AM_CFLAGS = -g -Wall -Werror $(LIBNL3_CFLAGS) $(READLINE_CFLAGS)
+AM_LDFLAGS = $(LIBNL3_LIBS) -lnl-genl-3 -lbfd $(READLINE_LIBS)
 AM_CPPFLAGS = -D_GNU_SOURCE
 
 dropwatch_SOURCES = main.c lookup_bfd.c lookup.c lookup_kas.c


### PR DESCRIPTION
Use pkg-config to get readline dependencies such as ncurses

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>