### PR TITLE
fix cast bug in big endian platform

### DIFF
--- a/src/lookup_kas.c
+++ b/src/lookup_kas.c
@@ -24,6 +24,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <sys/utsname.h>
 #include <bfd.h>
 #include <string.h>
@@ -146,9 +147,7 @@ static int lookup_kas_sym(void *pc, struct loc_result *location)
 {
 	__u64 pcv;
 
-	memset(&pcv, 0, sizeof(__u64));
-
-	memcpy(&pcv, &pc, sizeof(void *));
+	pcv = (uintptr_t)pc;
 
 	if (!lookup_kas_cache(pcv, location))
 		return 0;


### PR DESCRIPTION
In 32bit big endian platform, memcpy a 32bit pointer to u64 will get
a bad result.

Signed-off-by: xiaofan <xfan1024@live.com>