### PR TITLE
Fix for binutils 2.23.1

### DIFF
--- a/src/lookup.c
+++ b/src/lookup.c
@@ -24,6 +24,9 @@
  * 1) /usr/lib/debug/<kernel version> using libbfd
  * 2) /proc/kallsyms
  */
+
+#include "config.h"
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/utsname.h>

--- a/src/lookup_bfd.c
+++ b/src/lookup_bfd.c
@@ -22,6 +22,8 @@
  * symbollic name using the bfd library
  */
 
+#include "config.h"
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/utsname.h>

--- a/src/lookup_kas.c
+++ b/src/lookup_kas.c
@@ -22,6 +22,8 @@
  * symbolic name using /proc/kallsyms
  */
 
+#include "config.h"
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>


### PR DESCRIPTION
libbfd from binutils 2.23.1+ requires PACKAGE* definitions from autoconf.
Patch from https://fedorahosted.org/dropwatch/ticket/5
Upstream status: new.

Signed-off-by: Gustavo Zacarias <gustavo@zacarias.com.ar>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/dropwatch/0001-binutils-2.23.1.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>