### PR TITLE
Make binutils optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,15 @@ PKG_CHECK_MODULES([LIBNL3], [libnl-3.0], [], [AC_MSG_ERROR([libnl-3.0 is require
 # Fallback on using -lreadline as readline.pc is only available since version 8.0
 PKG_CHECK_MODULES([READLINE], [readline], [], [READLINE_LIBS=-lreadline])
 
+AC_ARG_WITH([bfd],
+	[AS_HELP_STRING([--without-bfd], [Build without bfd library (default: yes)])],
+	[with_bfd=$withval],
+	[with_bfd=yes])
+AS_IF([test "x$with_bfd" != "xno"], [
+	AC_CHECK_HEADERS([bfd.h], [], [AC_MSG_ERROR([Couldn't find or include bfd.h])])
+])
+AM_CONDITIONAL(USE_BFD, test "x$with_bfd" != "xno")
+
 AC_OUTPUT(Makefile src/Makefile doc/Makefile tests/Makefile)
 
 AC_MSG_NOTICE()
@@ -25,3 +34,4 @@ AC_MSG_NOTICE([Target:                 $target])
 AC_MSG_NOTICE([Installation prefix:    $prefix])
 AC_MSG_NOTICE([Compiler:               $CC])
 AC_MSG_NOTICE([Compiler flags: $CFLAGS])
+AC_MSG_NOTICE([BFD library support: $with_bfd])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,12 @@
 bin_PROGRAMS = dropwatch
 
 AM_CFLAGS = -g -Wall -Werror $(LIBNL3_CFLAGS) $(READLINE_CFLAGS)
-AM_LDFLAGS = $(LIBNL3_LIBS) -lnl-genl-3 -lbfd $(READLINE_LIBS)
+AM_LDFLAGS = $(LIBNL3_LIBS) -lnl-genl-3 $(READLINE_LIBS)
 AM_CPPFLAGS = -D_GNU_SOURCE
 
-dropwatch_SOURCES = main.c lookup_bfd.c lookup.c lookup_kas.c
+dropwatch_SOURCES = main.c lookup.c lookup_kas.c
+
+if USE_BFD
+dropwatch_SOURCES += lookup_bfd.c
+AM_LDFLAGS += -lbfd
+endif

--- a/src/lookup.c
+++ b/src/lookup.c
@@ -30,7 +30,9 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/utsname.h>
+#ifdef HAVE_BFD_H
 #include <bfd.h>
+#endif
 #include <string.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -38,7 +40,9 @@
 
 #include "lookup.h"
 
+#ifdef HAVE_BFD_H
 extern struct lookup_methods bfd_methods;
+#endif
 extern struct lookup_methods kallsym_methods;
 
 static int lookup_null_init(void)
@@ -75,17 +79,21 @@ int init_lookup(lookup_init_method_t method)
 		methods = &null_methods;
 		break;
 	case METHOD_AUTO:
+#ifdef HAVE_BFD_H
 		methods = &bfd_methods;
 		if (methods->lookup_init() == 0)
 			return 0;
+#endif
 		methods = &kallsym_methods;
 		if (methods->lookup_init() == 0)
 			return 0;
 		methods = NULL;
 		return -1;
+#ifdef HAVE_BFD_H
 	case METHOD_DEBUGINFO:
 		methods = &bfd_methods;
 		break;
+#endif
 	case METHOD_KALLSYMS:
 		methods = &kallsym_methods;
 		break;

--- a/src/lookup.h
+++ b/src/lookup.h
@@ -25,6 +25,8 @@
  * 2) /proc/kallsyms
  */
 
+#include "config.h"
+
 #include <stdlib.h>
 #include <asm/types.h>
 
@@ -44,7 +46,9 @@
 typedef enum {
 	METHOD_NULL = 0,
 	METHOD_AUTO,
+#ifdef HAVE_BFD_H
 	METHOD_DEBUGINFO,
+#endif
 	METHOD_KALLSYMS
 } lookup_init_method_t;
 

--- a/src/lookup_kas.c
+++ b/src/lookup_kas.c
@@ -28,7 +28,6 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <sys/utsname.h>
-#include <bfd.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/types.h>


### PR DESCRIPTION
Add an option to enable or disable bfd support to allow the user to use
dropwatch without binutils

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>