### PR TITLE
Add packet alert mode and monitoring of hardware originated drops

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Dropwatch is a project I started in an effort to improve the ability for
 developers and system administrator to diagnose problems in the Linux Networking
 stack, specifically in our ability to diagnose where packets are getting
 dropped.  From my probing, I've come to the conclusion that there are four main
-shortcommings in our current environment:
+shortcomings in our current environment:
 
 1) Consolidation, or lack thereof.  Currently, if you would like to check on the
 status of dropped packets in the kernel, you need to check at least 3 places,
 and possibly more: The /proc/net/snmp file, the netstat utility, the tc utility,
-and ethool.  This project aims to consolidate several of those checks into one
+and ethtool.  This project aims to consolidate several of those checks into one
 tool, making it easier for a sysadmin or developer to detect lost packets
 
-2) Clarity of information.  Dropped packets are not obvious.  a sysadmin needs
+2) Clarity of information.  Dropped packets are not obvious.  A sysadmin needs
 to be intimately familiar with each of the above tools to understand which
 events or statistics correlate to a dropped packet and which do not.  While that
 is often self evident, it is also often not.  Dropwatch aims to improve that
@@ -29,11 +29,11 @@ dropped packets are not always clear.  Does a UDPInError mean the application
 receive buffer was full, or does it mean its checksum was bad?  Dropwatch
 attempts to disambiguate the causes for dropped packets.
 
-4) Performance.  Utilties can be written to aggregate the data in the various
+4) Performance.  Utilities can be written to aggregate the data in the various
 other utilities to solve some of these problems, but such solutions require
 periodic polling of several interfaces, which is far from optimal, especially
 when lost packets are rare.  This solution improves on the performance aspect by
-implementing a kernel feature which allows asyncronous notification of dropped
+implementing a kernel feature which allows asynchronous notification of dropped
 packets when they happen.
 
 Building Dropwatch

--- a/doc/dropwatch.1
+++ b/doc/dropwatch.1
@@ -62,6 +62,14 @@ preparing a netlink message for each. This setting controls the queue's length.
 By default this is limited by the kernel to 1,000 packets. Increasing this
 value will increase the memory utilization of the system.
 .TP
+.BR "set sw " "{ " true " | " false " }"
+Enables or disables the monitoring of software originated drops. By default
+software originated drops are monitored.
+.TP
+.BR "set hw " "{ " true " | " false " }"
+Enables or disables the monitoring of hardware originated drops. By default
+hardware originated drops are not monitored.
+.TP
 .B show
 Query existing configuration from the kernel and show it.
 .TP

--- a/doc/dropwatch.1
+++ b/doc/dropwatch.1
@@ -61,3 +61,6 @@ Sets the queue length in the kernel. When \fIalertmode\fP is set to
 preparing a netlink message for each. This setting controls the queue's length.
 By default this is limited by the kernel to 1,000 packets. Increasing this
 value will increase the memory utilization of the system.
+.TP
+.B show
+Query existing configuration from the kernel and show it.

--- a/doc/dropwatch.1
+++ b/doc/dropwatch.1
@@ -64,3 +64,9 @@ value will increase the memory utilization of the system.
 .TP
 .B show
 Query existing configuration from the kernel and show it.
+.TP
+.B stats
+Query statistics from the kernel and show it.
+
+.I "Tail dropped"
+- Number of packets that could not be enqueued to the per-CPU drop list(s).

--- a/doc/dropwatch.1
+++ b/doc/dropwatch.1
@@ -54,3 +54,10 @@ Sets the truncation length. Reported packets will be truncated to length
 \fIlen\fP. This setting is only applicable when \fIalertmode\fP is set to
 \fIpacket\fP. By default packets are not truncated. A value of \fI0\fP disables
 truncation.
+.TP
+.BI "set queue " "len"
+Sets the queue length in the kernel. When \fIalertmode\fP is set to
+\fIpacket\fP, the kernel queues dropped packets in a per-CPU drop list before
+preparing a netlink message for each. This setting controls the queue's length.
+By default this is limited by the kernel to 1,000 packets. Increasing this
+value will increase the memory utilization of the system.

--- a/doc/dropwatch.1
+++ b/doc/dropwatch.1
@@ -48,3 +48,9 @@ alert includes drop locations and number of drops in each location.
 .I packet
 - Each dropped packet is sent to user space. The alert includes the packet
 itself and various metadata such as drop location and timestamp.
+.TP
+.BI "set trunc " "len"
+Sets the truncation length. Reported packets will be truncated to length
+\fIlen\fP. This setting is only applicable when \fIalertmode\fP is set to
+\fIpacket\fP. By default packets are not truncated. A value of \fI0\fP disables
+truncation.

--- a/doc/dropwatch.1
+++ b/doc/dropwatch.1
@@ -39,3 +39,12 @@ Displays summary of all commands.
 \fBset alertlimit\fP \fIvalue\fP
 Sets a triggerpoint to stop monitoring for dropped packets after \fIvalue\fP alerts
 have been received.
+.TP
+.BR "set alertmode " "{ " summary " | " packet " }"
+.I summary
+- Default mode. A summary of recent packet drops is sent to user space. The
+alert includes drop locations and number of drops in each location.
+
+.I packet
+- Each dropped packet is sent to user space. The alert includes the packet
+itself and various metadata such as drop location and timestamp.

--- a/spec/dropwatch.spec
+++ b/spec/dropwatch.spec
@@ -1,12 +1,12 @@
 %define uversion MAKEFILE_VERSION
-Summary: Kernel dropped packet monitor 
-Name: dropwatch 
-Version: %{uversion} 
-Release: 0%{?dist} 
+Summary: Kernel dropped packet monitor
+Name: dropwatch
+Version: %{uversion}
+Release: 0%{?dist}
 Source0: https://fedorahosted.org/releases/d/r/dropwatch/dropwatch-%{uversion}.tbz2
 URL: http://fedorahosted.org/dropwatch
-License: GPLv2+ 
-Group: Applications/System 
+License: GPLv2+
+Group: Applications/System
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: kernel-devel, libnl-devel, readline-devel
 BuildRequires: binutils-devel, binutils-static pkgconfig
@@ -22,7 +22,7 @@ network packets.
 %build
 cd src
 export CFLAGS=$RPM_OPT_FLAGS
-make 
+make
 
 %install
 rm -rf $RPM_BUILD_ROOT

--- a/src/lookup.c
+++ b/src/lookup.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009, Neil Horman <nhorman@redhat.com>
- * 
+ *
  * This program file is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
  * Free Software Foundation; version 2 of the License.

--- a/src/lookup.h
+++ b/src/lookup.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009, Neil Horman <nhorman@redhat.com>
- * 
+ *
  * This program file is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
  * Free Software Foundation; version 2 of the License.

--- a/src/lookup_bfd.c
+++ b/src/lookup_bfd.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009, Neil Horman <nhorman@redhat.com>
- * 
+ *
  * This program file is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
  * Free Software Foundation; version 2 of the License.

--- a/src/lookup_kas.c
+++ b/src/lookup_kas.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009, Neil Horman <nhorman@redhat.com>
- * 
+ *
  * This program file is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
  * Free Software Foundation; version 2 of the License.
@@ -47,8 +47,8 @@ LIST_HEAD(sym_list, symbol_entry);
 
 /*
  * This is our cache of symbols that we've previously looked up
- */ 
-static struct sym_list sym_list_head = {NULL}; 
+ */
+static struct sym_list sym_list_head = {NULL};
 
 
 static int lookup_kas_cache( __u64 pc, struct loc_result *location)
@@ -99,7 +99,7 @@ static int lookup_kas_proc(__u64 pc, struct loc_result *location)
 	uipc = pc;
 	ulpc = 0;
 	while (!feof(pf)) {
-		/* 
+		/*
 		 * Each line of /proc/kallsyms is formatteded as:
 		 *  - "%pK %c %s\n" (for kernel internal symbols), or
 		 *  - "%pK %c %s\t[%s]\n" (for module-provided symbols)
@@ -122,7 +122,7 @@ static int lookup_kas_proc(__u64 pc, struct loc_result *location)
 			fclose(pf);
 			free(name);
 			return lookup_kas_cache(pc, location);
-		} 
+		}
 
 		/*
  		 * Advance all our state holders
@@ -139,10 +139,9 @@ static int lookup_kas_proc(__u64 pc, struct loc_result *location)
 static int lookup_kas_init(void)
 {
 	printf("Initalizing kallsyms db\n");
-	
+
 	return 0;
 }
-
 
 static int lookup_kas_sym(void *pc, struct loc_result *location)
 {
@@ -160,4 +159,3 @@ struct lookup_methods kallsym_methods = {
 	lookup_kas_init,
 	lookup_kas_sym,
 };
-

--- a/src/main.c
+++ b/src/main.c
@@ -128,6 +128,7 @@ static struct nla_policy net_dm_policy[NET_DM_ATTR_MAX + 1] = {
 	[NET_DM_ATTR_ORIG_LEN]			= { .type = NLA_U32 },
 	[NET_DM_ATTR_QUEUE_LEN]			= { .type = NLA_U32 },
 	[NET_DM_ATTR_STATS]			= { .type = NLA_NESTED },
+	[NET_DM_ATTR_HW_STATS]			= { .type = NLA_NESTED },
 	[NET_DM_ATTR_ORIGIN]			= { .type = NLA_U16 },
 	[NET_DM_ATTR_HW_TRAP_GROUP_NAME]	= { .type = NLA_STRING },
 	[NET_DM_ATTR_HW_TRAP_NAME]		= { .type = NLA_STRING },
@@ -602,6 +603,11 @@ void handle_dm_stats_new_msg(struct netlink_message *msg, int err)
 	if (attrs[NET_DM_ATTR_STATS]) {
 		printf("Software statistics:\n");
 		print_nested_stats(attrs[NET_DM_ATTR_STATS]);
+	}
+
+	if (attrs[NET_DM_ATTR_HW_STATS]) {
+		printf("Hardware statistics:\n");
+		print_nested_stats(attrs[NET_DM_ATTR_HW_STATS]);
 	}
 
 out_free:

--- a/src/net_dropmon.h
+++ b/src/net_dropmon.h
@@ -44,6 +44,11 @@ enum {
 	NET_DM_CMD_CONFIG,
 	NET_DM_CMD_START,
 	NET_DM_CMD_STOP,
+	NET_DM_CMD_PACKET_ALERT,
+	NET_DM_CMD_CONFIG_GET,
+	NET_DM_CMD_CONFIG_NEW,
+	NET_DM_CMD_STATS_GET,
+	NET_DM_CMD_STATS_NEW,
 	_NET_DM_CMD_MAX,
 };
 
@@ -53,4 +58,65 @@ enum {
  * Our group identifiers
  */
 #define NET_DM_GRP_ALERT 1
+
+enum net_dm_attr {
+	NET_DM_ATTR_UNSPEC,
+
+	NET_DM_ATTR_ALERT_MODE,			/* u8 */
+	NET_DM_ATTR_PC,				/* u64 */
+	NET_DM_ATTR_SYMBOL,			/* string */
+	NET_DM_ATTR_IN_PORT,			/* nested */
+	NET_DM_ATTR_TIMESTAMP,			/* u64 */
+	NET_DM_ATTR_PROTO,			/* u16 */
+	NET_DM_ATTR_PAYLOAD,			/* binary */
+	NET_DM_ATTR_PAD,
+	NET_DM_ATTR_TRUNC_LEN,			/* u32 */
+	NET_DM_ATTR_ORIG_LEN,			/* u32 */
+	NET_DM_ATTR_QUEUE_LEN,			/* u32 */
+	NET_DM_ATTR_STATS,			/* nested */
+	NET_DM_ATTR_HW_STATS,			/* nested */
+	NET_DM_ATTR_ORIGIN,			/* u16 */
+	NET_DM_ATTR_HW_TRAP_GROUP_NAME,		/* string */
+	NET_DM_ATTR_HW_TRAP_NAME,		/* string */
+	NET_DM_ATTR_HW_ENTRIES,			/* nested */
+	NET_DM_ATTR_HW_ENTRY,			/* nested */
+	NET_DM_ATTR_HW_TRAP_COUNT,		/* u32 */
+	NET_DM_ATTR_SW_DROPS,			/* flag */
+	NET_DM_ATTR_HW_DROPS,			/* flag */
+
+	__NET_DM_ATTR_MAX,
+	NET_DM_ATTR_MAX = __NET_DM_ATTR_MAX - 1
+};
+
+/**
+ * enum net_dm_alert_mode - Alert mode.
+ * @NET_DM_ALERT_MODE_SUMMARY: A summary of recent drops is sent to user space.
+ * @NET_DM_ALERT_MODE_PACKET: Each dropped packet is sent to user space along
+ *                            with metadata.
+ */
+enum net_dm_alert_mode {
+	NET_DM_ALERT_MODE_SUMMARY,
+	NET_DM_ALERT_MODE_PACKET,
+};
+
+enum {
+	NET_DM_ATTR_PORT_NETDEV_IFINDEX,	/* u32 */
+	NET_DM_ATTR_PORT_NETDEV_NAME,		/* string */
+
+	__NET_DM_ATTR_PORT_MAX,
+	NET_DM_ATTR_PORT_MAX = __NET_DM_ATTR_PORT_MAX - 1
+};
+
+enum {
+	NET_DM_ATTR_STATS_DROPPED,		/* u64 */
+
+	__NET_DM_ATTR_STATS_MAX,
+	NET_DM_ATTR_STATS_MAX = __NET_DM_ATTR_STATS_MAX - 1
+};
+
+enum net_dm_origin {
+	NET_DM_ORIGIN_SW,
+	NET_DM_ORIGIN_HW,
+};
+
 #endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,3 +1,2 @@
-check_SCRIPTS = rundropwatch.sh 
+check_SCRIPTS = rundropwatch.sh
 TESTS = rundropwatch.sh
- 

--- a/tests/rundropwatch.sh
+++ b/tests/rundropwatch.sh
@@ -17,6 +17,3 @@ then
 		exit 77
 	fi
 fi
-
-
-


### PR DESCRIPTION
Hi,

The drop monitor kernel module was recently extended with two new features which are expected to be merged to the 5.4 kernel. This pull request adds support for these new features in DropWatch.

The first feature was merged in [this](https://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git/commit/?id=6e5ee483397aa02e5656191cb9f59e4095b4d249) kernel merge commit. It extends drop monitor with another alert mode in which dropped packets are notified to user space, instead of just a summary of recent drops. This enables users to perform a more detailed analysis of the dropped packets. Please refer to the kernel merge commit for example usage as well as to the individual commit messages in this pull request. The man page and help command were extended as well.

The second feature was merged in [this](https://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git/commit/?id=83beee5a3aff0fb159b2fb4d0cac8f18a193417e) kernel merge commit. It allows drop monitor to monitor hardware originated drops, in addition to software originated drops.

Patches #1-#2 perform simple clean-ups.

Patch #3 synchronizes the kernel header file.

Patches #4-#8 add support for packet alert mode.

Patches #9-#12 allow DropWatch to monitor hardware originated drops.

I have tested this patched DropWatch version on a net-next kernel and a net kernel. Also tested unmodified DropWatch on a net-next kernel.