### PR TITLE
Add libpcap-dev to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
       libreadline-dev
       libnl-3-dev
       libnl-genl-3-dev
+      libpcap-dev
 
 script: ./autogen.sh && ./configure && make && make check 
 


### PR DESCRIPTION
The recently added dwdump utility depends on libpcap. Add libpcap-dev as
a dependency in travis configuration file.

Fixes: 199440959a28 ("Add dwdump utility to dump kernel dropped packets to a file")
Signed-off-by: Ido Schimmel <idosch@mellanox.com>