### PR TITLE
Implement cookie printout in packet alert mode

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -501,6 +501,17 @@ void handle_dm_packet_alert_msg(struct netlink_message *msg, int err)
 	if (attrs[NET_DM_ATTR_IN_PORT])
 		print_nested_port(attrs[NET_DM_ATTR_IN_PORT], "input");
 
+	if (attrs[NET_DM_ATTR_FLOW_ACTION_COOKIE]) {
+		unsigned char *cookie = nla_data(attrs[NET_DM_ATTR_FLOW_ACTION_COOKIE]);
+		int cookie_len = nla_len(attrs[NET_DM_ATTR_FLOW_ACTION_COOKIE]);
+		int i;
+
+		printf("cookie: ");
+		for (i = 0; i < cookie_len; i++)
+			printf("%02x", cookie[i]);
+		printf("\n");
+	}
+
 	if (attrs[NET_DM_ATTR_TIMESTAMP]) {
 		time_t tv_sec;
 		struct tm *tm;

--- a/src/net_dropmon.h
+++ b/src/net_dropmon.h
@@ -86,6 +86,7 @@ enum net_dm_attr {
 	NET_DM_ATTR_HW_TRAP_COUNT,		/* u32 */
 	NET_DM_ATTR_SW_DROPS,			/* flag */
 	NET_DM_ATTR_HW_DROPS,			/* flag */
+	NET_DM_ATTR_FLOW_ACTION_COOKIE,		/* binary */
 
 	__NET_DM_ATTR_MAX,
 	NET_DM_ATTR_MAX = __NET_DM_ATTR_MAX - 1


### PR DESCRIPTION
If cookie is passed along, print it out in packet alert mode.

Example:
dropwatch> set hw true
setting hardware drops monitoring to 1
dropwatch> set alertmode packet
Setting alert mode
Alert mode successfully set
dropwatch> start
Enabling monitoring...
Kernel monitoring activated.
Issue Ctrl-C to stop monitoring
drop at: ingress_flow_action_drop (acl_drops)
origin: hardware
input port ifindex: 30
input port name: enp0s16np1
cookie: 31237981273918  <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
timestamp: Thu Jan 23 12:58:56 2020 434291226 nsec
protocol: 0x800
length: 98
original length: 98