### PR TITLE
Update distro to Xenial in the hopes that ubuntu will fix libpcap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-dist: trusty
+dist: xenial 
 
 compiler:
   - clang

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,9 @@ AC_CHECK_FUNCS(getopt_long)
 PKG_CHECK_MODULES([LIBNL3], [libnl-3.0], [], [AC_MSG_ERROR([libnl-3.0 is required])])
 # Fallback on using -lreadline as readline.pc is only available since version 8.0
 PKG_CHECK_MODULES([READLINE], [readline], [], [READLINE_LIBS=-lreadline])
-PKG_CHECK_MODULES([LIBPCAP], [libpcap])
+PKG_CHECK_MODULES([LIBPCAP], [libpcap], [], [
+        AC_CHECK_LIB(pcap, pcap_open_live,[],
+                [AC_MSG_ERROR([libpcap is required])])])
 
 AC_ARG_WITH([bfd],
 	[AS_HELP_STRING([--without-bfd], [Build without bfd library (default: yes)])],


### PR DESCRIPTION
libpcap in ubuntu is missing its .pc file, so autoconf fails.  They are
fixing it in newer releases but won't fix it in trusty, so lets home
updating the ci environment to xneial will get us an updated libpcap
package

Signed-off-by: Neil Horman <nhorman@tuxdriver.com>