### PR TITLE
Fix compilation error with old libnl

### DIFF
--- a/src/dwdump.c
+++ b/src/dwdump.c
@@ -24,7 +24,7 @@
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
-static const struct nla_policy net_dm_policy[NET_DM_ATTR_MAX + 1] = {
+static struct nla_policy net_dm_policy[NET_DM_ATTR_MAX + 1] = {
 	[NET_DM_ATTR_ALERT_MODE]		= { .type = NLA_U8 },
 	[NET_DM_ATTR_TRUNC_LEN]			= { .type = NLA_U32 },
 	[NET_DM_ATTR_QUEUE_LEN]			= { .type = NLA_U32 },
@@ -32,7 +32,7 @@ static const struct nla_policy net_dm_policy[NET_DM_ATTR_MAX + 1] = {
 	[NET_DM_ATTR_HW_STATS]			= { .type = NLA_NESTED },
 };
 
-static const struct nla_policy
+static struct nla_policy
 net_dm_stats_policy[NET_DM_ATTR_STATS_MAX + 1] = {
 	[NET_DM_ATTR_STATS_DROPPED]		= { .type = NLA_U64 },
 };


### PR DESCRIPTION
libnl commit b4802a17a765 ("nl: add "const" specifier for nla_policy
argument of parse functions") added 'const' qualifier to 'struct
nla_policy *' argument of the various *_parse() functions.

However, this commit is only present in libnl-3.5, whereas some
distributions are still shipping older versions.

This results in compilation errors such as:

```
dwdump.c:219:8: error: passing argument 5 of ‘genlmsg_parse’ discards
‘const’ qualifier from pointer target type
[-Werror=discarded-qualifiers]
```

Fix this by removing 'const' qualifier from the netlink attributes
policy structures in dwdump utility source. This is consistent with main
dropwatch utility source.

Fixes: 199440959a28 ("Add dwdump utility to dump kernel dropped packets to a file")
Signed-off-by: Ido Schimmel <idosch@mellanox.com>