### PR TITLE
Fix compilation error with old libpcap

### DIFF
--- a/src/dwdump.c
+++ b/src/dwdump.c
@@ -517,7 +517,7 @@ static int dwdump_pcap_init(struct dwdump *dwdump)
 	dwdump->pcap_dumper = pcap_dump_open(dwdump->pcap_handle,
 					     dwdump->options.dumpfile);
 	if (!dwdump->pcap_dumper) {
-		pcap_perror(dwdump->pcap_handle, dwdump->options.dumpfile);
+		pcap_perror(dwdump->pcap_handle, "pcap_dump_open");
 		goto err_dump_open;
 	}
 


### PR DESCRIPTION
libpcap commit 98e570c4d970 ("Make the second argument to pcap_perror()
const.") added 'const' qualifier to the second argument of
pcap_perror().

However, this commit is only present in libpcap-1.8, whereas some
distributions are still shipping older versions.

This results in compilation errors such as:

```
dwdump.c:520:36: error: passing argument 2 of ‘pcap_perror’ discards
‘const’ qualifier from pointer target type
[-Werror=discarded-qualifiers]
```

Fix this by passing the name of the function that failed - as we do with
perror() - instead of passing the name of the dump file that
pcap_dump_open() failed to open.

Fixes: 199440959a28 ("Add dwdump utility to dump kernel dropped packets to a file")
Signed-off-by: Ido Schimmel <idosch@mellanox.com>