### PR TITLE
Fix configure for libnl3-genl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AC_PROG_AWK
 AC_CHECK_FUNCS(getopt_long)
 
 PKG_CHECK_MODULES([LIBNL3], [libnl-3.0], [], [AC_MSG_ERROR([libnl-3.0 is required])])
+PKG_CHECK_MODULES([LIBNLG3], [libnl-genl-3.0], [], [AC_MSG_ERROR([libnl-genl-3.0 is required])])
 # Fallback on using -lreadline as readline.pc is only available since version 8.0
 PKG_CHECK_MODULES([READLINE], [readline], [], [READLINE_LIBS=-lreadline])
 PKG_CHECK_MODULES([LIBPCAP], [libpcap], [], [

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,8 +1,8 @@
 
 bin_PROGRAMS = dropwatch dwdump
 
-AM_CFLAGS = -g -Wall -Werror $(LIBNL3_CFLAGS) $(READLINE_CFLAGS)
-AM_LDFLAGS = $(LIBNL3_LIBS) -lnl-genl-3 $(READLINE_LIBS) -lpcap
+AM_CFLAGS = -g -Wall -Werror $(LIBNL3_CFLAGS) $(LIBNLG3_CFLAGS) $(READLINE_CFLAGS)
+AM_LDFLAGS = $(LIBNL3_LIBS) $(LIBNLG3_LIBS) $(READLINE_LIBS) -lpcap
 AM_CPPFLAGS = -D_GNU_SOURCE
 
 dropwatch_SOURCES = main.c lookup.c lookup_kas.c


### PR DESCRIPTION
Apparently, way back when we wrote the configure script, we included a
package check for libnl, but not libnl3-genl (ostensibly because it
didn't exist I think), and so we hardcoded linking to -lnl3-genl.  The
pkg-config file for that library exists now, so lets actually test for
it during the running of configure, and use its output during make

Signed-off-by: Neil Horman <nhorman@tuxdriver.com>