### PR TITLE
Fix fscanf error handling

### DIFF
--- a/src/lookup_kas.c
+++ b/src/lookup_kas.c
@@ -91,8 +91,13 @@ static int lookup_kas_proc(__u64 pc, struct loc_result *location)
 		 *  - "%pK %c %s\t[%s]\n" (for module-provided symbols)
 		 */
 		if (fscanf(pf, "%llx %*s %ms [ %*[^]] ]", (unsigned long long *)&ppc, &name) < 0) {
-			perror("Error Scanning File: ");
-			break;
+			if (ferror(pf)) {
+				perror("Error Scanning File: ");
+				break;
+			}
+			if (feof(pf)) {
+				continue;
+			}
 		}
 
 		uppc = (__u64)ppc;


### PR DESCRIPTION
Theres a problem with how we are managing EOF and error conditions in
kas scanning. Catch the error conditions properly and exit accordingly

Signed-off-by: Neil Horman <nhorman@tuxdriver.com>