### PR TITLE
Fix compilation error with gcc 11

### DIFF
--- a/src/lookup_bfd.c
+++ b/src/lookup_bfd.c
@@ -35,7 +35,7 @@ static int lookup_bfd_init(void)
 	if(uname(&uts)<0)
 		return-1;
 
-	dbibuf = malloc(strlen("/usr/lib/debug/lib/modules") + strlen(uts.release) + 1);
+	dbibuf = malloc(strlen("/usr/lib/debug/lib/modules/") + strlen(uts.release) + 1);
 	sprintf(dbibuf,"/usr/lib/debug/lib/modules/%s", uts.release);
 	if (stat(dbibuf,&sb) < 0) {
 		free(dbibuf);


### PR DESCRIPTION
Fix following compilation error:

lookup_bfd.c: In function ‘lookup_bfd_init’:
lookup_bfd.c:39:54: error: ‘sprintf’ may write a terminating nul past the end of the destination [-Werror=format-overflow=]
   39 |         sprintf(dbibuf,"/usr/lib/debug/lib/modules/%s", uts.release);
      |                                                      ^
lookup_bfd.c:39:9: note: ‘sprintf’ output between 28 and 287 bytes into a destination of size 286
   39 |         sprintf(dbibuf,"/usr/lib/debug/lib/modules/%s", uts.release);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Ido Schimmel <idosch@nvidia.com>