### PR TITLE
fix SOL_NETLINK undeclared error for glibc < 2.24

### DIFF
--- a/src/net_dropmon.h
+++ b/src/net_dropmon.h
@@ -6,6 +6,10 @@
 
 #include <linux/netlink.h>
 
+#ifndef SOL_NETLINK
+#define SOL_NETLINK     270
+#endif
+
 struct net_dm_drop_point {
 	__u8 pc[8];
 	__u32 count;


### PR DESCRIPTION
when compile with glibc < 2.24 that doesn't support SOL_NETLINK it will
cause compilation failure:

gcc -DHAVE_CONFIG_H -I. -I..  -D_GNU_SOURCE  -g -Wall -Werror -I/usr/include/libnl3 -I/usr/include/libnl3  -g -O2 -MT dwdump.o -MD -MP -MF $depbase.Tpo -c -o
 dwdump.o dwdump.c &&\
mv -f $depbase.Tpo $depbase.Po
dwdump.c: In function ‘dwdump_data_init’:
dwdump.c:126:23: error: ‘SOL_NETLINK’ undeclared (first use in this function)
  err = setsockopt(fd, SOL_NETLINK, NETLINK_NO_ENOBUFS, &optval,
                       ^
dwdump.c:126:23: note: each undeclared identifier is reported only once for each function it appears in
Makefile:422: recipe for target 'dwdump.o' failed
make[2]: *** [dwdump.o] Error 1

Signed-off-by: Sun Feng <loyou85@gmail.com>