### PR TITLE
configure.ac: Delete outdated comment about -lreadline

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,6 @@ AC_CHECK_FUNCS(getopt_long)
 
 PKG_CHECK_MODULES([LIBNL3], [libnl-3.0], [], [AC_MSG_ERROR([libnl-3.0 is required])])
 PKG_CHECK_MODULES([LIBNLG3], [libnl-genl-3.0], [], [AC_MSG_ERROR([libnl-genl-3.0 is required])])
-# Fallback on using -lreadline as readline.pc is only available since version 8.0
 PKG_CHECK_MODULES([READLINE], [readline], [], [AC_MSG_ERROR([libreadline is required])])
 PKG_CHECK_MODULES([LIBPCAP], [libpcap], [], [
         AC_CHECK_LIB(pcap, pcap_open_live,[],


### PR DESCRIPTION
Hi all,

I was trying to build dropwatch using Debian libreadline-dev 7.0-5 until I ran into this `.pc` thing.  The comment in `configure.ac` confused me a bit, and I think we should just delete it?

Thanks,
Peilin Ye

---
We removed the -lreadline hack for libreadline in commit c18f3d25a94e
("Update configure to fail if readline isn't installed").  Delete the
comment for less confusion.

Signed-off-by: Peilin Ye <peilin.ye@bytedance.com>