### PR TITLE
Fix compilation error with gcc 12

### DIFF
--- a/src/lookup_bfd.c
+++ b/src/lookup_bfd.c
@@ -35,7 +35,7 @@ static int lookup_bfd_init(void)
 	if(uname(&uts)<0)
 		return-1;
 
-	dbibuf = malloc(strlen("/usr/lib/debug/lib/modules/") + strlen(uts.release) + 1);
+	dbibuf = malloc(strlen("/usr/lib/debug/lib/modules/") + sizeof(uts.release));
 	sprintf(dbibuf,"/usr/lib/debug/lib/modules/%s", uts.release);
 	if (stat(dbibuf,&sb) < 0) {
 		free(dbibuf);


### PR DESCRIPTION
With gcc 12, there is a warning:

lookup_bfd.c: In function 'lookup_bfd_init':
lookup_bfd.c:39:52: error: '%s' directive writing up to 389 bytes into a region of size 260 [-Werror=format-overflow=]
   39 |         sprintf(dbibuf,"/usr/lib/debug/lib/modules/%s", uts.release);
      |                                                    ^~   ~~~~~~~~~~~
In file included from /usr/include/stdio.h:894,
                 from lookup_bfd.c:14:
In function 'sprintf',
    inlined from 'lookup_bfd_init' at lookup_bfd.c:39:2:
/usr/include/bits/stdio2.h:38:10: note: '__sprintf_chk' output between 28 and 417 bytes into a destination of size 287
   38 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   39 |                                   __glibc_objsize (__s), __fmt,
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   40 |                                   __va_arg_pack ());
      |                                   ~~~~~~~~~~~~~~~~~

Fix it by using sizeof() instead of strlen() to get the total size of
uts.release. Remove the last +1 since sizeof() will include the last NULL
character.

Signed-off-by: Hangbin Liu <liuhangbin@gmail.com>