### PR TITLE
packet drop reasons support

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -539,6 +539,10 @@ void handle_dm_packet_alert_msg(struct netlink_message *msg, int err)
 		printf("original length: %u\n",
 		       nla_get_u32(attrs[NET_DM_ATTR_ORIG_LEN]));
 
+	if (attrs[NET_DM_ATTR_REASON])
+		printf("drop reason: %s\n",
+		       nla_get_string(attrs[NET_DM_ATTR_REASON]));
+
 	printf("\n");
 
 	acount++;

--- a/src/net_dropmon.h
+++ b/src/net_dropmon.h
@@ -91,6 +91,7 @@ enum net_dm_attr {
 	NET_DM_ATTR_SW_DROPS,			/* flag */
 	NET_DM_ATTR_HW_DROPS,			/* flag */
 	NET_DM_ATTR_FLOW_ACTION_COOKIE,		/* binary */
+	NET_DM_ATTR_REASON,			/* string */
 
 	__NET_DM_ATTR_MAX,
 	NET_DM_ATTR_MAX = __NET_DM_ATTR_MAX - 1


### PR DESCRIPTION
In Linux 5.17, kfree_skb_reason() is added to the krenel, and packet
drop reason can be obtained from the skb/kfree_skb tracepoint.

Now, we can get packet drop reason from Linux drop-monitor module
with 'NET_DM_ATTR_REASON' attr. Therefore, make this tool supports
it.

Signed-off-by: Menglong Dong <imagedong@tencent.com>