### PR TITLE
spec: add libtool as build requirement

### DIFF
--- a/spec/dropwatch.spec
+++ b/spec/dropwatch.spec
@@ -8,8 +8,9 @@ URL: http://fedorahosted.org/dropwatch
 License: GPLv2+
 Group: Applications/System
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+BuildRequires: autoconf, automake, libtool
 BuildRequires: kernel-devel, libnl-devel, readline-devel
-BuildRequires: binutils-devel, binutils-static pkgconfig
+BuildRequires: binutils-devel, binutils-static, pkgconfig
 Requires: libnl, readline
 
 %description


### PR DESCRIPTION
Let's add autoconf, automake, libtool as a build requirements
to spec file. It may be useful for users who building
dropwatch "by hands" as a reference.

I've spent some time in debugging dropwatch build problem:
```lookup_bfd.o: In function `lookup_bfd_init':
/root/dropwatch/src/lookup_bfd.c:48: undefined reference to `bfd_init'```

the reason was in absence of libtool in my system. As a result
not correct gcc invocation command was constructed by autoconf:

`gcc -g -Wall -Werror -I... -g -O2 -lnl-3   -lnl-genl-3 -l...   -lpcap -lbfd  -o dropwatch main.o lookup.o lookup_kas.o lookup_bfd.o  -lpcap`

the problem here is that we have -lbfd mentioned *before* object files, so ld
just forget about bfd symbols.

Installing libtool and regeneration of the build scripts/Makefile solves the problem.

Signed-off-by: Alexander Mikhalitsyn <alexander.mikhalitsyn@virtuozzo.com>