### PR TITLE
Add support for net namespace filtering

### DIFF
--- a/src/net_dropmon.h
+++ b/src/net_dropmon.h
@@ -13,6 +13,7 @@
 struct net_dm_drop_point {
 	__u8 pc[8];
 	__u32 count;
+	__u32 ns_id;
 };
 
 #define NET_DM_CFG_VERSION  0
@@ -92,6 +93,8 @@ enum net_dm_attr {
 	NET_DM_ATTR_HW_DROPS,			/* flag */
 	NET_DM_ATTR_FLOW_ACTION_COOKIE,		/* binary */
 	NET_DM_ATTR_REASON,			/* string */
+	NET_DM_ATTR_NS,				/* u32 */
+	NET_DM_ATTR_HW_NS,			/* u32 */
 
 	__NET_DM_ATTR_MAX,
 	NET_DM_ATTR_MAX = __NET_DM_ATTR_MAX - 1


### PR DESCRIPTION
When investigating dropped packet issues on hosts running multiple containers it can be helpful to narrow down the search by either filtering for a specific container i.e. the inum of its net namespace, or just see the netnamespace where a particular drop originated from.

Introduce this support by extending the netlink protocol with the addition of NET_DM_ATTR_NS which configures the kernel-level component to filter based on the passed in id. The command has 3 variations:

 - "set ns 0" / "set ns" - this means no filtering should occur but the output in dropwatch will contain the net namespace where the drop originated:

     11 drops at location 0xffffffffaf8cd963 [software] [ns: 4026532536]

 - "set ns inum" - where inum is a positive number, larger than 0, this instructs the kernel component to record drops only from this net namespace

 - "set ns off" - turns off namespace printing and returns the output to the default and disable kernel level filtering.

This is the userspace code, the kernel can be found at https://lore.kernel.org/netdev/20221121133132.1837107-1-nikolay.borisov@virtuozzo.com/T/#m4795d0e1855d181043a7ee7bc57e72e0397ed838

Signed-off-by: Nikolay Borisov <nikolay.borisov@virtuozzo.com>